### PR TITLE
Tweaked to pick up Affiliation tag correctly

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -429,7 +429,10 @@ exports.parse = function(pathOrPipe, constantCallback, callback) {
 			json[json.length-1].personalNameSubjects[json[json.length-1].personalNameSubjects.length-1][type] = text;
 		} else if(whereAmI[whereAmI.length-2] === "Investigator") {
 			json[json.length-1].investigators[json[json.length-1].investigators.length-1][type] = text;
+		} else if(whereAmI[whereAmI.length-2] === "AffiliationInfo" && whereAmI[whereAmI.length-3] === "Author") {
+			json[json.length-1].authors.list[json[json.length-1].authors.list.length-1][type] = text;
 		}
+
 	}
 
 	function grantInsertion(text, type) {


### PR DESCRIPTION
2016 DTD apparently dictates that Affiliation tags be wrapped in AffiliationInfo tags (personInsertion func did not account for this). Fixed by checking three two levels up, rather than one.
